### PR TITLE
FIX BUG: 查询成绩时，若信息门户返回的table中某个td标签内包含自标签时，对查询结果进行提取会出现错误

### DIFF
--- a/uestc/query.py
+++ b/uestc/query.py
@@ -2,7 +2,7 @@
 """查询信息"""
 import json
 from .exceptions import QueryError
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString
 __all__ = ['get_now_semesterid', 'get_semesterid_data', 'get_score']
 
 
@@ -33,6 +33,11 @@ def get_score(login_session, semester):
     ret = []
 
     for i in range(len(result)):
+        result[i].string = "".join(list(filter(lambda x: isinstance(x, NavigableString), result[i].descendants)))
+        # 特殊情况下,名为'td'的标签内部可能嵌套有其他标签
+        # 如: "<td>微积分I<span style="color:red;">(重修)</span></td>"
+        # 此时result[i].string值为None，在下一步中调用时会出现错误:"AttributeError: 'NoneType' object has no attribute 'replace'"
+        # 通过上面的均一化处理，保证result[i].string不为None
         result[i].string = result[i].string.replace('\n', '').replace('\r', '').replace('\t', '').replace(' ', '')
     for i in range(len(result) // 10):
         ret.append(result[i * 10 : i * 10 + 10])


### PR DESCRIPTION
出现问题时的报错信息：

```python
Traceback (most recent call last):
  File "C:/_code/uestc/main.py", line 4, in <module>
    grade = uestc.query.get_score(session, '2015-2016-2')
  File "C:\_code\uestc\uestc\query.py", line 36, in get_score
    result[i].string = result[i].string.replace('\n', '').replace('\r', '').replace('\t', '').replace(' ', '')
AttributeError: 'NoneType' object has no attribute 'replace'
```

异常部分代码：

```python
for i in range(len(result)):
  result[i].string = result[i].string.replace('\n', '').replace('\r', '').replace('\t', '').replace(' ', '')
```

查看引起异常的数据内容，将上部分代码修改为如下形式：

```python
for i in range(len(result)):
  try:
      result[i].string = result[i].string.replace('\n', '').replace('\r', '').replace('\t', '').replace(' ', '')
  except Exception as e:
      print(result[i])
      raise e
```

运行结果：

```python
<td>微积分I<span style="color:red;">(重修)</span></td>
Traceback (most recent call last):
  File "C:/_code/uestc/main.py", line 4, in <module>
    grade = uestc.query.get_score(session, '2015-2016-2')
  File "C:\_code\uestc\uestc\query.py", line 41, in get_score
    raise e
  File "C:\_code\uestc\uestc\query.py", line 38, in get_score
    result[i].string = result[i].string.replace('\n', '').replace('\r', '').replace('\t', '').replace(' ', '')
AttributeError: 'NoneType' object has no attribute 'replace'
```

递归获取内部文本内容并加以拼接，用于修复该Bug的代码如下：

```python
result[i].string = "".join(list(filter(lambda x: isinstance(x, NavigableString), result[i].descendants)))
```